### PR TITLE
#patch Cleared and re-generated `project.godot` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Godot 4+ specific ignores
 .godot/
+!.godot/global_script_class_cache.cfg
+!.godot/extension_list.cfg
 /android/
 dist/*
 /build_win/

--- a/project.godot
+++ b/project.godot
@@ -43,7 +43,7 @@ window/stretch/mode="canvas_items"
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/func_godot/plugin.cfg", "res://addons/godot_state_charts/plugin.cfg", "res://addons/input_helper/plugin.cfg", "res://addons/sound_manager/plugin.cfg")
+enabled=PackedStringArray("res://addons/godot_state_charts/plugin.cfg", "res://addons/input_helper/plugin.cfg", "res://addons/sound_manager/plugin.cfg")
 
 [global_group]
 

--- a/project.godot
+++ b/project.godot
@@ -43,7 +43,7 @@ window/stretch/mode="canvas_items"
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/godot_state_charts/plugin.cfg", "res://addons/input_helper/plugin.cfg", "res://addons/sound_manager/plugin.cfg")
+enabled=PackedStringArray("res://addons/func_godot/plugin.cfg", "res://addons/godot_state_charts/plugin.cfg", "res://addons/input_helper/plugin.cfg", "res://addons/sound_manager/plugin.cfg")
 
 [global_group]
 


### PR DESCRIPTION
Fix suggested in https://github.com/godotengine/godot/issues/92833:
> I'm pretty certain that the problem is caused by the fact that the global_script_class_cache.cfg file does not exist so global classes are not loaded when trying to import and compile all in one shot.

Deleted the `.godot` directory and regenerated it with `godot --path ./ --import --build-solutions --headless`
